### PR TITLE
Added region templates

### DIFF
--- a/mkdocs/architecture/Configuration.md
+++ b/mkdocs/architecture/Configuration.md
@@ -44,7 +44,6 @@ AccountIndexGeneratorShip:
     Enabled: True
     TemplatePrefix: AccountIndexGenerator/us-east-2.yaml
     InvocationQueueUrl: https://sqs.DEPLOYEMENT-REGION.amazonaws.com/ACCOUNT-ID/starfleet-account-index-generator
-    FanOutStrategy: SINGLE_INVOCATION
     InvocationSources:
         - EVENTBRIDGE_TIMED_EVENT
     EventBridgeTimedFrequency: HOURLY
@@ -69,6 +68,7 @@ The base configuration configures the primary Starfleet components. This is in t
 * **`AccountIndex`** - This is the _name_ of the Account Index plugin that Starfleet will use for getting an inventory of AWS accounts. This is outlined in more detail later, but is required. By default, this will use the `StarfleetDefaultAccountIndex` plugin which relies on the `AccountIndexGeneratorShip` worker ship to generate an AWS account inventory for an AWS Organization. That is also described later, but for now just know that Starfleet needs to know which plugin to consult with to obtain an index or inventory of AWS accounts and their enabled regions.
 
 #### Optional Fields
+* **`ScopeToRegions`** - This is a set of AWS regions that should be scoped for `ACCOUNT_REGION` worker templates. This is useful if you have an SCP that restricts the regions that are allowed to be operated in. This ensures that `ACCOUNT_REGION` workers can only operate in those regions specified in this list. By default this is not set.
 * **`LogLevel`** - This is the Python log level to make use of. The valid fields are the [Python log level names](https://docs.python.org/3/library/logging.html#levels). The default value is `INFO`.
 * **`ThirdPartyLoggerLevels`** - This is a dictionary of Python logger name, and the corresponding log level for it. By default we silence the loggers for `botocore` and `urllib3.connectionpool`, because they can be noisy when making `boto3` API calls. Feel free to add or modify this section as you see fit.
 
@@ -79,7 +79,6 @@ Each worker ship must have a configuration entry. The configuration entry has a 
 * **`Enabled`** - Each worker ship needs to have this field, which is set to the boolean of `True` or `False`. This specifies if the worker ship plugin is enabled or not.
 * **`TemplatePrefix`** - As described in the [Worker Ship section](WorkerShips.md#the-payload-template), this specifies where in the S3 bucket the worker ship's payload templates are located.
 * **`InvocationQueueUrl`** - As described in the [Worker Ship section](WorkerShips.md#the-sqs-queue), this is the SQS queue URL for where the Lambda's invocation will happen. The AWS SAM template has an example of what this should be. If you rely on the SAM template, than simply swap out the account ID and region, and you are good to go!
-* **`FanOutStrategy`** - As described in the [Worker Ship section](WorkerShips.md#fan-out-strategy), this defines the fan out strategy for the given worker. This is used to inform the Starbase component how to task the worker.
 * **`InvocationSources`** - As described in the [Worker Ship section](WorkerShips.md#invocation-source), this defines when the given worker gets invoked. This is used to inform the Starbase component when to task the worker.
 
 !!! Note

--- a/mkdocs/architecture/PayloadTemplates.md
+++ b/mkdocs/architecture/PayloadTemplates.md
@@ -175,4 +175,64 @@ ExcludeAccounts:
 ```
 
 ## Account-Region Worker Templates
-This is not yet implemented but will be similar to above only with Regional context as well.
+This is very similar to the account worker templates because it _is_ an account worker template but has some additional properties to include and exclude regions to operate in. All of the account worker options are true for account-region worker templates.
+
+The big difference is that account-region worker templates have 2 additional fields:
+
+1. __`IncludeRegions`__ - This is a list of AWS regions to operate on *--OR--* a list where the only entry is the word `ALL` to operate for all regions (See example below).
+1. __`ExcludeRegions`__ - This is a list of AWS regions to *NOT* operate on.
+
+!!! note "Very Important"
+    There is a configuration property in the `STARFLEET` configuration stanza that sets an override for the specific regions that can be operated on named `ScopeToRegions`. This is useful for restricting the regions that Starfleet can operate on if you, for example, have an SCP enabled to disable regions at the organization level.
+
+The Starbase will resolve accounts where the following properties are true:
+
+1. Accounts are specified in the template and are not excluded
+1. There are regions specified to operate over and are not excluded
+1. The account is enabled in the regions specified
+1. If the `ScopeToRegions` configuration field is set, then the regions specified are within the `ScopeToRegions` list
+
+### Some Examples
+
+Here are some examples where everything comes together:
+
+Here is an example of a template that will operate on every single account in every single enabled region (including the root account):
+```yaml
+IncludeAccounts:
+    AllAccounts: True
+IncludeRegions:
+    - ALL
+OperateInOrgRoot: True
+```
+
+Here is an example of only running in 3 regions in 3 specific accounts:
+```yaml
+IncludeAccounts:
+    ByNames:
+        - InfoSec Staging
+        - Marketing Staging
+        - DevOps Staging
+IncludeRegions:
+    - us-east-1
+    - us-east-2
+    - ca-central-1
+```
+
+Here is an example of applying to the `Infsec Staging` account, all accounts in the `DevOps`, `Financial`, and `Marketing` OUs and _excluding_ accounts named `DevOps Prod`, and `Financial Prod`, and all enabled regions _except_ `us-west-1`.
+```yaml
+IncludeAccounts:
+    ByNames:
+        - InfoSec Staging
+    ByOrgUnits:
+        - DevOps
+        - Financial
+        - Marketing
+ExcludeAccounts:
+    ByNames:
+        - DevOps Prod
+        - Financial Prod
+IncludeRegions:
+    - ALL
+ExcludeRegions:
+    - us-west-1
+```

--- a/mkdocs/architecture/WorkerShips.md
+++ b/mkdocs/architecture/WorkerShips.md
@@ -22,34 +22,6 @@ The next section of the documentation goes into more detail about Starfleet's co
 
 For now, just know that workers require a configuration entry that details what is required for it to execute properly.
 
-### Fan Out Strategy
-All workers have what is called a ==Fan Out Strategy==. This describes how a worker should be tasked. This defines whether or not a worker should be tasked to operate as a single invocation, or if there should be a worker dedicated to each AWS account, or a worker dedicated to each AWS account and region pair.
-
-The following are the values that can be set:
-
-```yaml
-# This means that there is 1 Lambda function required to complete the task. No AWS account context is provided to the worker.
-- SINGLE_INVOCATION
-
-# This means that there should be 1 Lambda function for each AWS account to complete the task. Most workers would likely require this.
-# This will provide the AWS account ID to the worker that it should operate in. The worker would assume an IAM role in that account in order
-# to operate within in.
-- ACCOUNT
-
-# This means that there is 1 Lambda function for each account AND enabled AWS region. This is very similar to the ACCOUNT fan out, but this one
-# also includes context on the region to operate in as well (only if that region is enabled for the given AWS account).
-# This will spawn the most Lambda invocations.
-- ACCOUNT_REGION
-```
-
-This is set via the `FanOutStrategy` configuration field for the worker. Example for a worker that operates in each AWS account:
-
-```yaml
-FanOutStrategy: ACCOUNT
-```
-
-A worker can only define 1 fan out strategy.
-
 ### The SQS Queue
 Each worker ship has an SQS queue and a corresponding dead-letter queue (DLQ). The SQS queue for the worker is used for invoking the Lambda function. SQS is used for a variety of reasons, namely it scales Lambda invocations very nicely, has great retry-capabilities, and DLQ integration. The DLQ is used to help debug why given payloads have failed.
 
@@ -81,6 +53,28 @@ The `InvocationSources` is a list and thus the worker can be invoked by a variet
 
 !!! warning
     There are other invocation sources that are being considered, like SNS or SQS, but that has not yet been ironed out or implemented. At this time the `InvocationSources` configuration is subject to change.
+
+## The Fan Out Strategy
+All workers have what is called a ==Fan Out Strategy==. This describes how a worker should be tasked. This defines whether or not a worker should be tasked to operate as a single invocation, or if there should be a worker dedicated to each AWS account, or a worker dedicated to each AWS account and region pair.
+
+This is a property of the worker ship itself and defined in the code for it. The developer guide has more details, but for now a worker can be coded for one of the following 3 options:
+
+```yaml
+# This means that there is 1 Lambda function required to complete the task. No AWS account context is provided to the worker.
+- SINGLE_INVOCATION
+
+# This means that there should be 1 Lambda function for each AWS account to complete the task. Most workers would likely require this.
+# This will provide the AWS account ID to the worker that it should operate in. The worker would assume an IAM role in that account in order
+# to operate within in.
+- ACCOUNT
+
+# This means that there is 1 Lambda function for each account AND enabled AWS region. This is very similar to the ACCOUNT fan out, but this one
+# also includes context on the region to operate in as well (only if that region is enabled for the given AWS account).
+# This will spawn the most Lambda invocations.
+- ACCOUNT_REGION
+```
+
+A worker can only be configured to have one fan out strategy.
 
 ## The Payload Template
 More information is provided about the payload YAML templates in the next sections, but the key thing to note is that each worker ship has at least 1 YAML payload template. The template is intended to inform the worker what it needs to do in an invocation. Each worker defines it's own template schema (using the Python [Marshmallow](https://marshmallow.readthedocs.io/en/stable/)). A worker can be configured to support many templates. An example would be a worker that synchronizes IAM roles; in this example, there would be 1 template for each IAM role that Starfleet maintains.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+; The option below will break click unit tests: https://github.com/pallets/click/issues/824
+log_cli = false
+usefixtures = mock_retry

--- a/src/starfleet/account_index/resolvers.py
+++ b/src/starfleet/account_index/resolvers.py
@@ -10,12 +10,14 @@ This defines the account resolution logic for account and account/region templat
 from typing import Any, Dict, Set
 
 from starfleet.account_index.loader import ACCOUNT_INDEX
+from starfleet.utils.configuration import STARFLEET_CONFIGURATION
+from starfleet.utils.logging import LOGGER
 
 
 def resolve_worker_template_accounts(loaded_template: Dict[str, Any]) -> Set[str]:
     """
     This will resolve the accounts that a given worker template is supposed to operate on. This receives a deserialized dictionary that was based on the
-    `starfleet.worker_ships.base_playload_schemas.BaseAccountPayloadTemplate` (or a subclass or equivalent).
+    `starfleet.worker_ships.base_payload_schemas.BaseAccountPayloadTemplate` (or a subclass or equivalent).
     """
     # Get the accounts:
     resolved_accounts = resolve_include_exclude(loaded_template)
@@ -30,10 +32,53 @@ def resolve_worker_template_accounts(loaded_template: Dict[str, Any]) -> Set[str
     return resolved_accounts
 
 
+def resolve_worker_template_account_regions(loaded_template: Dict[str, Any]) -> Dict[str, Set[str]]:
+    """
+    This will resolve the accounts/regions that a given worker template is supposed to operate on. This receives a deserialized dictionary that was based on the
+    `starfleet.worker_ships.base_payload_schemas.BaseAccountRegionPayloadTemplate` (or a subclass or equivalent).
+
+    This will return a Dictionary of the account ID and set of regions to operate over.
+
+    This is scoped to the `STARFLEET` configuration value for `ScopeToRegions`. If that is set, then that is the maximum list of regions that can be tasked.
+    """
+    # Get the accounts:
+    resolved_accounts = resolve_worker_template_accounts(loaded_template)
+
+    # Grab the requested regions:
+    excluded_regions = loaded_template["exclude_regions"] if loaded_template["exclude_regions"] else set()
+    resolved_regions = loaded_template["include_regions"] - excluded_regions
+
+    # Build the account/region map:
+    account_region_map = {}
+
+    # If a scope is applied in the `STARFLEET` configuration's `ScopeToRegions` variable, then apply the scoping:
+    scoped_regions = set(STARFLEET_CONFIGURATION.config["STARFLEET"].get("ScopeToRegions", []))
+    if scoped_regions:
+        LOGGER.debug(f"[🌐] Region scoping is enabled to only task within the following regions: {', '.join(scoped_regions)}")
+        regions_accounts_map = {}
+        # Fetch the region->accounts mapping but we are only going to process them if it's permitted in the scope:
+        for region, accounts in ACCOUNT_INDEX.index.get_accounts_by_regions(resolved_regions).items():
+            if region in scoped_regions:
+                regions_accounts_map[region] = accounts
+
+    # No scoping is set, so just use the raw index results:
+    else:
+        regions_accounts_map = ACCOUNT_INDEX.index.get_accounts_by_regions(resolved_regions)
+
+    # Build the map account->regions map if the account is enabled for the region (and the region is specified in the template):
+    for account in resolved_accounts:
+        account_region_map[account] = set()
+        for region, region_accounts in regions_accounts_map.items():
+            if account in region_accounts:
+                account_region_map[account].add(region)
+
+    return account_region_map
+
+
 def resolve_include_exclude(loaded_template: Dict[str, Any]) -> Set[str]:
     """
     This will resolve accounts that are included and excluded. This will return a set of accounts that are effectively included (sans the excluded accounts).
-    This receives a deserialized dictionary that was based on the `starfleet.worker_ships.base_playload_schemas.BaseAccountPayloadTemplate` (or a subclass or equivalent).
+    This receives a deserialized dictionary that was based on the `starfleet.worker_ships.base_payload_schemas.BaseAccountPayloadTemplate` (or a subclass or equivalent).
     """
     included_accounts = resolve_include_account_specification(loaded_template["include_accounts"])
     excluded_accounts = resolve_account_specification(loaded_template["exclude_accounts"]) if loaded_template["exclude_accounts"] else set()
@@ -44,7 +89,7 @@ def resolve_include_exclude(loaded_template: Dict[str, Any]) -> Set[str]:
 
 def resolve_account_specification(account_spec: Dict[str, Any]) -> Set[str]:
     """
-    This will receive a dictionary that is based on the `starfleet.worker_ships.base_playload_schemas.AccountsSpecificationSchema` (or a subclass or equivalent)
+    This will receive a dictionary that is based on the `starfleet.worker_ships.base_payload_schemas.AccountsSpecificationSchema` (or a subclass or equivalent)
     AND has already been deserialized.
 
     This will go through each account portion and return a giant set of each account in there.

--- a/src/starfleet/configuration_files/configuration.yaml
+++ b/src/starfleet/configuration_files/configuration.yaml
@@ -1,5 +1,5 @@
 STARFLEET:
-  DeploymentRegion: REPLACE-ME
+  DeploymentRegion: us-east-1  # Replace me
   TemplateBucket: REPLACE-ME
   FanOutQueueUrl: https://some.url.amazonaws.com/replace-me
   AccountIndex: StarfleetDefaultAccountIndex
@@ -13,7 +13,6 @@ AccountIndexGeneratorShip:
   Enabled: True
   TemplatePrefix: AccountIndexGenerator/REPLACE-ME.YAML
   InvocationQueueUrl: https://replace.me.sqs.amazonaws.com/REPLACE-ME
-  FanOutStrategy: SINGLE_INVOCATION
   InvocationSources:
     - EVENTBRIDGE_TIMED_EVENT
   EventBridgeTimedFrequency: HOURLY

--- a/src/starfleet/utils/config_schema.py
+++ b/src/starfleet/utils/config_schema.py
@@ -8,14 +8,18 @@ has the correct components on it.
 :License: See the LICENSE file for details
 :Author: Mike Grima <michael.grima@gemini.com>
 """
+import boto3
 from marshmallow import Schema, fields, INCLUDE, validate
+
+aws_regions = set(boto3.session.Session().get_available_regions("ec2"))
 
 
 class StarfleetSchema(Schema):
     """This is the main schema for Starfleet itself."""
 
     # Required Fields:
-    deployment_region = fields.String(required=True, data_key="DeploymentRegion")  # This is where all Starfleet resources (SQS, S3, etc.) reside.
+    # This is where all Starfleet resources (SQS, S3, etc.) reside.
+    deployment_region = fields.String(required=True, data_key="DeploymentRegion", validate=validate.OneOf(aws_regions))
     template_bucket = fields.String(required=True, data_key="TemplateBucket")  # This is the name of the S3 bucket that all the templates will reside.
     # This is the SQS queue URL that the Starbase will use for getting the worker/template details so that the worker ship can be tasked properly:
     fanout_queue_url = fields.Url(required=True, schemes={"https"}, data_key="FanOutQueueUrl")
@@ -24,9 +28,16 @@ class StarfleetSchema(Schema):
     account_index = fields.String(required=False, data_key="AccountIndex", load_default="StarfleetDefaultAccountIndex")
 
     # Optional fields:
+    # This is a field that limits the ACCOUNT_REGION workers such that there are specific regions that can be operated on.
+    # If this is set, then you can only run in the regions defined here despite what regions an account has enabled:
+    scope_to_regions = fields.List(fields.String(validate=validate.OneOf(aws_regions)), required=False, data_key="ScopeToRegions", load_default=[])
+    # ^^ This is useful if you have an SCP that disables regions; this prevents Starfleet to run in regions that are disabled by SCP.
+
+    # Log Level:
     log_level = fields.String(
         required=False, load_default="INFO", validate=validate.OneOf({"CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"}), data_key="LogLevel"
     )
+    # Dictionary to override log levels for 3rd party loggers. This is the name of the log and the level.
     third_party_logger_levels = fields.Dict(required=False, data_key="ThirdPartyLoggerLevels")
 
 

--- a/src/starfleet/worker_ships/ship_schematics.py
+++ b/src/starfleet/worker_ships/ship_schematics.py
@@ -73,9 +73,6 @@ class WorkerShipBaseConfigurationTemplate(Schema):
     # This is the SQS queue URL that will be used to invoke this function. This is used by the Starbase to know where to message the ship invocation action:
     invocation_queue_url = fields.Url(required=True, schemes={"https"}, data_key="InvocationQueueUrl")
 
-    # This is the fan-out strategy, and needs to be set to the Enum values above:
-    fan_out_strategy = fields.Enum(FanOutStrategy, required=True, data_key="FanOutStrategy")
-
     # This is the invocation sources. This needs to be specified.
     invocation_sources = fields.List(fields.Enum(InvocationSources), required=True, data_key="InvocationSources")
 
@@ -109,10 +106,10 @@ class StarfleetWorkerShip:
 
     The instantiated object type hint is `StarFleetWorkerShipInstance`."""
 
-    # Need to define the invocation details. This is the InvocationSource and the corresponding InvocationConfiguration
-    # for it. This informs the Starbase on if an invocation event is in fact for this given worker ship.
-    # invocation_details: Dict[InvocationSource, InvocationConfiguration]
-    # TODO: should this be part of the worker itself or part of the configuration? I'm leaning on the former and not the latter (current)
+    # TODO: Should the invocation sources be defined here or the configuration?? (right now it's in the configuration)
+
+    # This is the fan out strategy for the worker. This is very important and defines the type of job the worker is supposed to do (this also influences the template type).
+    fan_out_strategy: FanOutStrategy = FanOutStrategy.SINGLE_INVOCATION
 
     # This is the name for the worker ship plugin (this should be UpperCamelCase). This is also the name of the Configuration section for the given worker ship plugin:
     worker_ship_name: str

--- a/tests/account_index/conftest.py
+++ b/tests/account_index/conftest.py
@@ -9,20 +9,24 @@ This defines the PyTest fixtures for the Account Indexer tests
 """
 # pylint: disable=unused-argument
 from typing import Generator, Any, Dict
-from unittest import mock
 
 import pytest
 
-from starfleet.account_index.loader import StarfleetAccountIndexLoader, AccountIndexInstance
-import tests.account_index.testing_plugins.basic_plugin
+from starfleet.account_index.loader import AccountIndexInstance
 
 
 @pytest.fixture
 def test_index(test_configuration: Dict[str, Any]) -> Generator[AccountIndexInstance, None, None]:
-    """This returns the StarfleetAccountIndexLoader with a TestingAccountIndexPlugin configured for it."""
+    """This returns the StarfleetAccountIndexLoader with a TestingAccountIndexPlugin mocked out for it. This mocks out for the entire app."""
+    from starfleet.account_index.loader import ACCOUNT_INDEX, StarfleetAccountIndexLoader
+    import tests.account_index.testing_plugins
+
     account_indexer = StarfleetAccountIndexLoader()
     account_indexer._index_ship_path = tests.account_index.testing_plugins.__path__
     account_indexer._index_ship_prefix = tests.account_index.testing_plugins.__name__ + "."
 
-    with mock.patch("starfleet.account_index.loader.ACCOUNT_INDEX", account_indexer):
-        yield account_indexer.index
+    # Just mock out the index. The singleton function will simply return the populated index attribute:
+    ACCOUNT_INDEX._index = account_indexer.index
+    yield ACCOUNT_INDEX.index
+
+    ACCOUNT_INDEX.reset()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,21 @@ def aws_sts(aws_credentials: None) -> BaseClient:
 
 @pytest.fixture
 def mock_retry() -> None:
-    """This mocks out the retry decorator so things don't block."""
+    """
+    This mocks out the retry decorator so things don't block.
+
+    NOTE: GOTCHA ALERT:
+    This fixture must be run **BEFORE** you import from a file that contains the @retry decorator. This is because this mocks out the original function.
+    When imported AFTER the fixture is set, then you are importing the mocked out @retry decorator. If you import from a file with the @retry decorator in it
+    BEFORE this fixture is set, then the function is decorated with the original @retry decorator. This is due to the way that Python imports work
+    where the Python package stores the reference to the imported item. Mocking out *the original* place does not override the local package's reference
+    to the dependency -- only mocking out the *the local* package import would do that.
+
+    In this case, we want to mock out the original such that we don't have to make N fixtures for each and every place that uses @retry. This means you
+    need to be careful about the imports in conftest.py and other places to ensure that mock_retry is set before the imports are run in the target place.
+
+    ## ALSO NOTE: This runs on *each and every* test -- set in pytest.ini
+    """
 
     def mock_retry_decorator(*args, **kwargs) -> Callable:  # noqa
         """This mocks out the retry decorator."""

--- a/tests/starbase/test_starbase.py
+++ b/tests/starbase/test_starbase.py
@@ -97,16 +97,10 @@ def test_fan_out_single_invocation(
     fanout_payload_lambda_handler(fanout_lambda_payload, object())
 
     # Confirm that the queue got the correct payload:
-    messages = aws_sqs.receive_message(QueueUrl=worker_queue, MaxNumberOfMessages=10).get("Messages")
+    messages = aws_sqs.receive_message(QueueUrl=worker_queue, MaxNumberOfMessages=10, WaitTimeSeconds=0).get("Messages")
     worker = worker_ships.get_worker_ships()["TestingStarfleetWorkerPlugin"]
     worker.load_template(json.loads(messages[0]["Body"]))
     assert worker.payload["template_name"] == "TestWorkerTemplate"
-
-    with mock.patch("starfleet.starbase.main.LOGGER") as mocked_logger:
-        # TODO: Remove this when we add more invocation types:
-        test_configuration["TestingStarfleetWorkerPlugin"]["FanOutStrategy"] = "ACCOUNT_REGION"
-        fanout_payload_lambda_handler(fanout_lambda_payload, object())
-        assert mocked_logger.warning.call_args.args[0] == "[🚧] Fan Out Strategy: ACCOUNT_REGION is not implemented yet!"
 
 
 def test_fan_out_account(
@@ -167,6 +161,36 @@ def test_account_fanout_nothing_to_task(test_index: AccountIndexInstance) -> Non
     assert "has no accounts to task" in mocked_logger.error.call_args[0][0]
 
 
+def test_account_region_fanout_nothing_to_task(test_index: AccountIndexInstance) -> None:
+    """This tests that we log out that we have no accounts/regions to task if the template fails to resolve to any actual account/region pairs."""
+    from starfleet.starbase.utils import account_region_fanout
+    from starfleet.worker_ships.base_payload_schemas import BaseAccountRegionPayloadTemplate
+
+    # Include and exclude regions are the same:
+    template = {
+        "include_accounts": {"all_accounts": True, "by_names": [], "by_ids": [], "by_tags": [], "by_org_units": []},
+        "exclude_accounts": {},
+        "operate_in_org_root": True,
+        "include_regions": set("us-east-1"),
+        "exclude_regions": set("us-east-1"),
+    }
+    with mock.patch("starfleet.starbase.utils.LOGGER") as mocked_logger:
+        account_region_fanout(template, BaseAccountRegionPayloadTemplate(), "", "", "", boto3.client("sqs", region_name="us-east-1"), "fake_ship")
+    assert "has no accounts/regions to task" in mocked_logger.error.call_args[0][0]
+
+    # And with no accounts, but regions:
+    template = {
+        "include_accounts": {"all_accounts": False, "by_names": ["fake_account"], "by_ids": [], "by_tags": [], "by_org_units": []},
+        "exclude_accounts": {},
+        "operate_in_org_root": True,
+        "include_regions": set("us-east-1"),
+        "exclude_regions": [],
+    }
+    with mock.patch("starfleet.starbase.utils.LOGGER") as mocked_logger:
+        account_region_fanout(template, BaseAccountRegionPayloadTemplate(), "", "", "", boto3.client("sqs", region_name="us-east-1"), "fake_ship")
+    assert "has no accounts/regions to task" in mocked_logger.error.call_args[0][0]
+
+
 def test_account_fanout_wrong_subclass(
     fanout_lambda_payload: Dict[str, Any],
     template_bucket: str,
@@ -174,15 +198,21 @@ def test_account_fanout_wrong_subclass(
     test_index: AccountIndexInstance,
     aws_s3: BaseClient,
     worker_ships: StarfleetWorkerShipLoader,
-    test_configuration: Dict[str, Any],
 ) -> None:
     """This tests that we check if we have an Account worker with a template that doesn't properly subclass the BaseAccountPayloadTemplate class."""
     from starfleet.starbase.entrypoints import fanout_payload_lambda_handler
     from starfleet.starbase.main import InvalidTemplateForFanoutError
+    from starfleet.worker_ships.ship_schematics import FanOutStrategy
 
     # Update the worker class configuration to be an ACCOUNT worker:
-    test_configuration["TestingStarfleetWorkerPlugin"]["FanOutStrategy"] = "ACCOUNT"
+    ship = worker_ships.get_worker_ships()["TestingStarfleetWorkerPlugin"]
+    ship.fan_out_strategy = FanOutStrategy.ACCOUNT
+    with pytest.raises(InvalidTemplateForFanoutError):
+        fanout_payload_lambda_handler(fanout_lambda_payload, object())
 
+    # Update the worker class configuration to be an ACCOUNT_REGION worker:
+    ship = worker_ships.get_worker_ships()["TestingStarfleetWorkerPlugin"]
+    ship.fan_out_strategy = FanOutStrategy.ACCOUNT_REGION
     with pytest.raises(InvalidTemplateForFanoutError):
         fanout_payload_lambda_handler(fanout_lambda_payload, object())
 
@@ -216,3 +246,52 @@ def test_multiple_records_warning_fanout(test_index: AccountIndexInstance) -> No
             fanout_payload_lambda_handler({"Records": [{"body": "1"}, {"body": "2"}]}, object())
 
     assert mocked_logger.error.call_args.args[0].startswith("[🚨] Received more than 1 event for fan out!")
+
+
+# pylint: disable=too-many-locals
+def test_fan_out_account_regions(
+    aws_s3: BaseClient,
+    aws_sqs: BaseClient,
+    fanout_lambda_payload: Dict[str, Any],
+    template_bucket: str,
+    account_region_payload_templates: Set[str],
+    test_configuration: Dict[str, Any],
+    worker_queue: str,
+    account_region_worker_ships: StarfleetWorkerShipLoader,
+    test_index: AccountIndexInstance,
+) -> None:
+    """Tests that we can properly fan out the payload for account/region workers. This also tests the utility function."""
+    from starfleet.starbase.entrypoints import fanout_payload_lambda_handler
+
+    fanout_payload_lambda_handler(fanout_lambda_payload, object())
+
+    # Confirm that the queue got the correct payload:
+    all_messages = []
+    while True:
+        messages = aws_sqs.receive_message(QueueUrl=worker_queue, MaxNumberOfMessages=10, WaitTimeSeconds=0).get("Messages")
+        if not messages:
+            break
+
+        all_messages += messages
+
+    # There should be 18 messages, because we tasked 16 account/regions
+    # [5 accounts - Account 1 = 4 accounts total tasked * (5 regions - 1 excluded = 4 regions) ==> 4 * 4 = 16 tasks]
+    assert len(all_messages) == 16
+
+    # Iterate through and verify that everything is correct. Also verify and confirm that we are not tasking the org root (Account 20), and Account 1 which is explicitly
+    # excluded in the template by name:
+    worker = account_region_worker_ships.get_worker_ships()["TestingStarfleetWorkerPlugin"]
+    all_accounts_regions = test_index.get_accounts_by_regions({"us-west-1", "us-east-1", "us-east-2", "eu-west-1", "ca-central-1"})
+    for message in all_messages:
+        worker.load_template(json.loads(message["Body"]))
+        # Remove the seen account/regions. If not found, this will raise an exception.
+        # At the end only 2 accounts should remain (20, and 1) which are excluded and 1 region (us-west-1):
+        all_accounts_regions[worker.payload["starbase_assigned_region"]].remove(worker.payload["starbase_assigned_account"])
+        assert worker.payload["template_name"] == "TestWorkerTemplate"
+
+    assert all_accounts_regions.pop("us-west-1") == test_index.get_all_accounts()  # us-west-1 wasn't tasked
+    for region in ["us-east-1", "us-east-2", "eu-west-1", "ca-central-1"]:
+        # Verify that for the remaining regions, we have tasked the accounts in those regions. If we did, then we removed the account
+        # from the set. So the intersection of the accounts we were supposed to task with the region map is empty.
+        assert not all_accounts_regions.pop(region).intersection({"000000000002", "000000000003", "000000000004", "000000000005"})
+    assert not all_accounts_regions  # nothing should be remaining, which means we have fully verified everything

--- a/tests/starfleet_included_plugins/account_index_generator/test_account_indexer_ship.py
+++ b/tests/starfleet_included_plugins/account_index_generator/test_account_indexer_ship.py
@@ -83,7 +83,11 @@ def test_get_account_map(account_map: Dict[str, Any]) -> None:
 
 
 def test_fetch_additional_details(
-    aws_ec2: BaseClient, aws_sts: BaseClient, mock_retry: None, account_map: Dict[str, Any], mock_direct_boto_clients: MagicMock, test_worker_ship_loader
+    aws_ec2: BaseClient,
+    aws_sts: BaseClient,
+    account_map: Dict[str, Any],
+    mock_direct_boto_clients: MagicMock,
+    test_worker_ship_loader: StarfleetWorkerShipLoader,
 ) -> None:
     """This is a test to ensure that we can fetch all the additional details about"""
     from starfleet.worker_ships.plugins.account_index_generator.utils import fetch_additional_details
@@ -111,7 +115,7 @@ def test_fetch_additional_details(
             assert account["Parents"] == [{"Id": "r-123456", "Type": "ROOT", "Name": "ROOT"}]
 
 
-def test_async_exceptions(aws_sts: BaseClient, mock_retry: None) -> None:
+def test_async_exceptions(aws_sts: BaseClient) -> None:
     """This tests that we can handle exceptions right if there are async issues."""
     from starfleet.worker_ships.plugins.account_index_generator.utils import AccountIndexerProcessError, fetch_additional_details
 
@@ -138,7 +142,6 @@ def test_full_run(
     aws_sts: BaseClient,
     inventory_bucket: str,
     mock_list_parent_ous: None,
-    mock_retry: None,
     account_map: Dict[str, Any],
     mock_direct_boto_clients: MagicMock,
     lambda_payload: Dict[str, Any],

--- a/tests/test_configuration_files/account_index_generator.yaml
+++ b/tests/test_configuration_files/account_index_generator.yaml
@@ -2,7 +2,6 @@ AccountIndexGeneratorShip:
   Enabled: True
   TemplatePrefix: sample_worker/
   InvocationQueueUrl: https://sqs.amazonaws.com/replace-me
-  FanOutStrategy: SINGLE_INVOCATION
   InvocationSources:
       - EVENTBRIDGE_TIMED_EVENT
   EventBridgeTimedFrequency: HOURLY

--- a/tests/test_configuration_files/basic_plugin.yaml
+++ b/tests/test_configuration_files/basic_plugin.yaml
@@ -2,7 +2,6 @@ TestingStarfleetWorkerPlugin:
   Enabled: True
   TemplatePrefix: TestingStarfleetWorkerPlugin/
   InvocationQueueUrl: https://us-east-2.queue.amazonaws.com/123456789012/WorkerQueue1
-  FanOutStrategy: SINGLE_INVOCATION
   InvocationSources:
       - S3
       - EVENTBRIDGE_TIMED_EVENT
@@ -13,7 +12,6 @@ TestingStarfleetWorkerPluginTwo:
   Enabled: True
   TemplatePrefix: TestingStarfleetWorkerPluginTwo/
   InvocationQueueUrl: https://us-east-2.queue.amazonaws.com/123456789012/WorkerQueue2
-  FanOutStrategy: SINGLE_INVOCATION
   InvocationSources:
       - S3
       - EVENTBRIDGE_TIMED_EVENT
@@ -24,7 +22,6 @@ TestingStarfleetWorkerPluginThree:
   Enabled: True
   TemplatePrefix: TestingStarfleetWorkerPluginThree/
   InvocationQueueUrl: https://us-east-2.queue.amazonaws.com/123456789012/WorkerQueue3
-  FanOutStrategy: SINGLE_INVOCATION
   InvocationSources:
       - S3
       - EVENTBRIDGE_TIMED_EVENT

--- a/tests/worker_ship_utils/conftest.py
+++ b/tests/worker_ship_utils/conftest.py
@@ -20,7 +20,6 @@ SAMPLE_GOOD_CONFIG = """
 Enabled: False
 TemplatePrefix: somePrefix/
 InvocationQueueUrl: https://sqs.amazonaws.com/SomeQueueUrl
-FanOutStrategy: SINGLE_INVOCATION
 InvocationSources:
     - S3
     - EVENTBRIDGE_TIMED_EVENT


### PR DESCRIPTION
- Implemented the Account/Region templates and resolvers.
- Implemented the Account/Region fan out logic.
- Added a scoping variable to the `STARFLEET` configuration for scoping ACCOUNT_REGION worker ship regions.
- This also removes the configuration field for `FanOutStrategy`, and instead this was moved into the worker class definition itself. This makes more sense as it's very much hard-coded for the worker and is not something that should be overwritable via a configuration.
- Fixed bug where an emtpy dict can be provided for `IncludeAccounts`.
- Updated the documentation to reflect changes in this PR.