### PR TITLE
fix: mark safe use of insecure hashing algorithm

### DIFF
--- a/src/starfleet/worker_ships/plugins/github_sync/utils.py
+++ b/src/starfleet/worker_ships/plugins/github_sync/utils.py
@@ -161,7 +161,7 @@ def match_path(file_path: str, regex_list: List[str]) -> bool:
 def generate_s3_hash(file_path: str) -> str:
     """Generates the S3 e-tag hash of the file. This determines if the file is the same as the file that is existing in S3 or not."""
     # See https://zihao.me/post/calculating-etag-for-aws-s3-objects/ for details: -- using 4 MB chunks for checksum.
-    value_md5 = hashlib.md5()
+    value_md5 = hashlib.md5(usedforsecurity=False)
     with open(file_path, "rb") as file:
         for data in iter(lambda: file.read(4096), b""):
             value_md5.update(data)


### PR DESCRIPTION
In restricted environments, use of insecure hashing algorithms like MD5 is prohibited in any security context. This change marks the use of `hashlib.md5` as safe since it is only used to compute a non-cryptographic one-way checksum for S3 object entity tags.

This change will also resolve the high severity finding that is currently generated by Bandit when scanning the project:

```shell
❯ bandit -r ./starfleet/src/
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: None
[main]	INFO	running on Python 3.11.3
Run started:2023-05-01 20:31:55.796667

Test results:
>> Issue: [B324:hashlib] Use of weak MD5 hash for security. Consider usedforsecurity=False
   Severity: High   Confidence: High
   CWE: CWE-327 (https://cwe.mitre.org/data/definitions/327.html)
   More Info: https://bandit.readthedocs.io/en/1.7.5/plugins/b324_hashlib.html
   Location: ./starfleet/src/starfleet/worker_ships/plugins/github_sync/utils.py:164:16
163	    # See https://zihao.me/post/calculating-etag-for-aws-s3-objects/ for details: -- using 4 MB chunks for checksum.
164	    value_md5 = hashlib.md5()
165	    with open(file_path, "rb") as file:
```