### PR TITLE
Fixes Event Bridge Time Frequency condition to evaluate the `event_detail.name` as string instead of a list

### DIFF
--- a/src/starfleet/starbase/main.py
+++ b/src/starfleet/starbase/main.py
@@ -50,7 +50,7 @@ def process_eventbridge_timed_event(event: Dict[str, Any]) -> None:
         # Does the worker ship listen to EventBridge?
         if "EVENTBRIDGE_TIMED_EVENT" in config["InvocationSources"]:
             # If yes, is this an event that it should care for?
-            if event_detail.name in config["EventBridgeTimedFrequency"]:
+            if event_detail.name == config["EventBridgeTimedFrequency"]:
                 need_to_task.append((worker_ship, config))
 
     if not need_to_task:


### PR DESCRIPTION
When Starfleet is determining what workerships to task for an Event Bridge Timed event , it iterates over its config to identify which workerships to task. The workership config item it is evaluating is stored as String.  The current implementation evaluates it as a List and this changes it to a String.