### PR TITLE
[WIP] fix: resolve crash in organizations with nested OUs

### DIFF
--- a/src/starfleet/worker_ships/plugins/account_index_generator/ship.py
+++ b/src/starfleet/worker_ships/plugins/account_index_generator/ship.py
@@ -71,7 +71,6 @@ class AccountIndexGeneratorShip(StarfleetWorkerShip):
             org_account_id=config["OrgAccountId"],
             org_account_role_name=config["OrgAccountAssumeRole"],
         )
-
         # Fetch the tags and enabled regions:
         LOGGER.info("[🚚] Fetching tags and enabled regions for each account...")
         fetch_additional_details(

--- a/src/starfleet/worker_ships/plugins/account_index_generator/ship.py
+++ b/src/starfleet/worker_ships/plugins/account_index_generator/ship.py
@@ -24,7 +24,6 @@ from starfleet.worker_ships.lambda_utils import worker_lambda
 from starfleet.worker_ships.plugins.account_index_generator.utils import (
     fetch_additional_details,
     list_accounts,
-    list_organizational_units_for_parent,
     get_account_map,
     get_organizational_unit_map,
 )

--- a/src/starfleet/worker_ships/plugins/account_index_generator/ship.py
+++ b/src/starfleet/worker_ships/plugins/account_index_generator/ship.py
@@ -24,8 +24,9 @@ from starfleet.worker_ships.lambda_utils import worker_lambda
 from starfleet.worker_ships.plugins.account_index_generator.utils import (
     fetch_additional_details,
     list_accounts,
-    get_account_map,
     list_organizational_units_for_parent,
+    get_account_map,
+    get_organizational_unit_map,
 )
 from starfleet.worker_ships.ship_schematics import StarfleetWorkerShip, WorkerShipBaseConfigurationTemplate
 from starfleet.worker_ships.base_payload_schemas import WorkerShipPayloadBaseTemplate
@@ -66,11 +67,11 @@ class AccountIndexGeneratorShip(StarfleetWorkerShip):
 
         # Fetch the list of org OUs:
         LOGGER.info("[📡] Reaching out to the Orgs API to get the list of all OUs in the org...")
-        all_ous = list_organizational_units_for_parent(  # pylint: disable=no-value-for-parameter
-            ParentId=config["OrgRootId"], account_number=config["OrgAccountId"], assume_role=config["OrgAccountAssumeRole"]
+        ou_map = get_organizational_unit_map(
+            parent_id=config["OrgRootId"],
+            org_account_id=config["OrgAccountId"],
+            org_account_role_name=config["OrgAccountAssumeRole"],
         )
-        ou_map = {ou["Id"]: ou["Name"] for ou in all_ous}  # noqa  # Reformat the data into a nice map
-        ou_map[config["OrgRootId"]] = "ROOT"  # Add the root in
 
         # Fetch the tags and enabled regions:
         LOGGER.info("[🚚] Fetching tags and enabled regions for each account...")

--- a/src/starfleet/worker_ships/plugins/account_index_generator/utils.py
+++ b/src/starfleet/worker_ships/plugins/account_index_generator/utils.py
@@ -54,7 +54,7 @@ def get_organizational_unit_map(
     org_account_role_name: str,
     client: Optional[BaseClient] = None,
 ) -> dict[str, Any]:
-    """Recursively lists all OUs contained Returns a map of all OU names keyed to their identifier, searching recursively."""
+    """Recursively lists all OUs, returning a map of all OU names keyed to their identifier."""
     ou_map: dict[str, str] = {}
     if client is None:
         client: BaseClient = boto3_cached_conn(service="organizations", account_number=org_account_id, assume_role=org_account_role_name)

--- a/tests/account_index/test_resolvers.py
+++ b/tests/account_index/test_resolvers.py
@@ -54,10 +54,10 @@ def test_resolve_include_account_specification(test_index: AccountIndexInstance)
         "by_ids": [],
         "by_names": [],
         "by_tags": [],
-        "by_org_units": ["ROOT", "SomeOU", "r-123456", "ou-1234-5678910"],
+        "by_org_units": ["ROOT", "Workloads", "r-abcd", "ou-abcd-e604f59w"],
     }
     results["ou_loop"] = resolve_include_account_specification(template["include_accounts"])
-    for org_unit in ["ROOT", "r-123456"]:
+    for org_unit in ["ROOT", "r-abcd"]:
         template["include_accounts"] = {"all_accounts": False, "by_ids": [], "by_names": [], "by_tags": [], "by_org_units": [org_unit]}
         results[f"ou_key_{org_unit}"] = resolve_include_account_specification(template["include_accounts"])
 
@@ -71,7 +71,7 @@ def test_resolve_include_account_specification(test_index: AccountIndexInstance)
         assert all_accounts == value
 
     # Lastly, check out the non-root OU since that will lack the org root ID (Account 20):
-    for org_unit in ["SomeOU", "ou-1234-5678910"]:
+    for org_unit in ["Workloads", "ou-abcd-e604f59w"]:
         template["include_accounts"] = {"all_accounts": False, "by_ids": [], "by_names": [], "by_tags": [], "by_org_units": [org_unit]}
         result = resolve_include_account_specification(template["include_accounts"])
         assert "000000000020" not in result
@@ -111,7 +111,7 @@ def test_resolve_include_exclude(test_index: AccountIndexInstance) -> None:
             AllAccounts: True
         ExcludeAccounts:
             ByOrgUnits:
-                - SomeOU
+                - Workloads
     """
     template = BaseAccountPayloadTemplate().load(yaml.safe_load(payload))
     assert resolve_include_exclude(template) == {"000000000020"}

--- a/tests/starfleet_included_plugins/account_index_generator/generatedIndex.json
+++ b/tests/starfleet_included_plugins/account_index_generator/generatedIndex.json
@@ -2,7 +2,7 @@
     "accounts": {
         "000000000001": {
             "Id": "000000000001",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000001",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000001",
             "Email": "account1@company.com",
             "Name": "Account 1",
             "Status": "ACTIVE",
@@ -15,12 +15,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -61,7 +61,7 @@
         },
         "000000000002": {
             "Id": "000000000002",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000002",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000002",
             "Email": "account2@company.com",
             "Name": "Account 2",
             "Status": "ACTIVE",
@@ -74,12 +74,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -120,7 +120,7 @@
         },
         "000000000003": {
             "Id": "000000000003",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000003",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000003",
             "Email": "account3@company.com",
             "Name": "Account 3",
             "Status": "ACTIVE",
@@ -133,12 +133,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -179,7 +179,7 @@
         },
         "000000000004": {
             "Id": "000000000004",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000004",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000004",
             "Email": "account4@company.com",
             "Name": "Account 4",
             "Status": "ACTIVE",
@@ -192,12 +192,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -238,7 +238,7 @@
         },
         "000000000005": {
             "Id": "000000000005",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000005",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000005",
             "Email": "account5@company.com",
             "Name": "Account 5",
             "Status": "ACTIVE",
@@ -251,12 +251,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -297,7 +297,7 @@
         },
         "000000000006": {
             "Id": "000000000006",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000006",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000006",
             "Email": "account6@company.com",
             "Name": "Account 6",
             "Status": "ACTIVE",
@@ -310,12 +310,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -356,7 +356,7 @@
         },
         "000000000007": {
             "Id": "000000000007",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000007",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000007",
             "Email": "account7@company.com",
             "Name": "Account 7",
             "Status": "ACTIVE",
@@ -369,12 +369,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -415,7 +415,7 @@
         },
         "000000000008": {
             "Id": "000000000008",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000008",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000008",
             "Email": "account8@company.com",
             "Name": "Account 8",
             "Status": "ACTIVE",
@@ -428,12 +428,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -474,7 +474,7 @@
         },
         "000000000009": {
             "Id": "000000000009",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000009",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000009",
             "Email": "account9@company.com",
             "Name": "Account 9",
             "Status": "ACTIVE",
@@ -487,12 +487,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -533,7 +533,7 @@
         },
         "000000000010": {
             "Id": "000000000010",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000010",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000010",
             "Email": "account10@company.com",
             "Name": "Account 10",
             "Status": "ACTIVE",
@@ -546,12 +546,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -592,7 +592,7 @@
         },
         "000000000011": {
             "Id": "000000000011",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000011",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000011",
             "Email": "account11@company.com",
             "Name": "Account 11",
             "Status": "ACTIVE",
@@ -605,12 +605,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -651,7 +651,7 @@
         },
         "000000000012": {
             "Id": "000000000012",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000012",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000012",
             "Email": "account12@company.com",
             "Name": "Account 12",
             "Status": "ACTIVE",
@@ -664,12 +664,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -710,7 +710,7 @@
         },
         "000000000013": {
             "Id": "000000000013",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000013",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000013",
             "Email": "account13@company.com",
             "Name": "Account 13",
             "Status": "ACTIVE",
@@ -723,12 +723,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -769,7 +769,7 @@
         },
         "000000000014": {
             "Id": "000000000014",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000014",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000014",
             "Email": "account14@company.com",
             "Name": "Account 14",
             "Status": "ACTIVE",
@@ -782,12 +782,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -828,7 +828,7 @@
         },
         "000000000015": {
             "Id": "000000000015",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000015",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000015",
             "Email": "account15@company.com",
             "Name": "Account 15",
             "Status": "ACTIVE",
@@ -841,12 +841,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -887,7 +887,7 @@
         },
         "000000000016": {
             "Id": "000000000016",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000016",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000016",
             "Email": "account16@company.com",
             "Name": "Account 16",
             "Status": "ACTIVE",
@@ -900,12 +900,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -946,7 +946,7 @@
         },
         "000000000017": {
             "Id": "000000000017",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000017",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000017",
             "Email": "account17@company.com",
             "Name": "Account 17",
             "Status": "ACTIVE",
@@ -959,12 +959,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -1005,7 +1005,7 @@
         },
         "000000000018": {
             "Id": "000000000018",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000018",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000018",
             "Email": "account18@company.com",
             "Name": "Account 18",
             "Status": "ACTIVE",
@@ -1018,12 +1018,12 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-e604f59w",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Workloads"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -1064,7 +1064,7 @@
         },
         "000000000019": {
             "Id": "000000000019",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000019",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000019",
             "Email": "account19@company.com",
             "Name": "Account 19",
             "Status": "ACTIVE",
@@ -1077,12 +1077,17 @@
             },
             "Parents": [
                 {
-                    "Id": "ou-1234-5678910",
+                    "Id": "ou-abcd-q8z9vop9",
                     "Type": "ORGANIZATIONAL_UNIT",
-                    "Name": "SomeOU"
+                    "Name": "Prod"
                 },
                 {
-                    "Id": "r-123456",
+                    "Id": "ou-abcd-e604f59w",
+                    "Type": "ORGANIZATIONAL_UNIT",
+                    "Name": "Workloads"
+                },
+                {
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }
@@ -1123,7 +1128,7 @@
         },
         "000000000020": {
             "Id": "000000000020",
-            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghi/000000000020",
+            "Arn": "arn:aws:organizations::000000000020:account/o-abcdefghij/000000000020",
             "Email": "account20@company.com",
             "Name": "Account 20",
             "Status": "ACTIVE",
@@ -1136,7 +1141,7 @@
             },
             "Parents": [
                 {
-                    "Id": "r-123456",
+                    "Id": "r-abcd",
                     "Type": "ROOT",
                     "Name": "ROOT"
                 }

--- a/tests/starfleet_included_plugins/account_index_generator/test_account_indexer_ship.py
+++ b/tests/starfleet_included_plugins/account_index_generator/test_account_indexer_ship.py
@@ -113,7 +113,6 @@ def test_fetch_additional_details(
         elif account["Id"] == "000000000020":
             assert account["Parents"] == [{"Id": "r-abcd", "Type": "ROOT", "Name": "ROOT"}]
         elif account["Id"] == "000000000019":
-            print(f"\n######\n{account['Parents']}\n######\n")
             assert account["Parents"] == [
                 {"Id": "ou-abcd-q8z9vop9", "Type": "ORGANIZATIONAL_UNIT", "Name": "Prod"},
                 {"Id": "ou-abcd-e604f59w", "Type": "ORGANIZATIONAL_UNIT", "Name": "Workloads"},
@@ -207,8 +206,6 @@ def test_full_run(
             account.pop("JoinedTimestamp")
 
         # Verify that the output inventory JSON is exactly what it's supposed to be:
-        print(f"\n########################\n{json.dumps(account_index)}\n########################\n")
-        print(f"\n########################\n{json.dumps(account_map)}\n########################\n")
         assert account_index == account_map
 
     # Clean up the env var:

--- a/tests/starfleet_included_plugins/account_index_generator/test_default_account_index.py
+++ b/tests/starfleet_included_plugins/account_index_generator/test_default_account_index.py
@@ -64,8 +64,8 @@ def test_loading(account_index_config: Dict[str, Any], aws_s3: BaseClient, inven
     for region_mapping in index.regions_map.values():
         assert len(region_mapping) == len(account_map.keys())
 
-    assert len(index.ou_map["r-123456"]) == len(index.ou_map["ROOT".lower()]) == len(account_map.keys())
-    assert len(index.ou_map["ou-1234-5678910"]) == len(index.ou_map["SomeOU".lower()]) == len(account_map.keys()) - 1
+    assert len(index.ou_map["r-abcd"]) == len(index.ou_map["ROOT".lower()]) == len(account_map.keys())
+    assert len(index.ou_map["ou-abcd-e604f59w"]) == len(index.ou_map["Workloads".lower()]) == len(account_map.keys()) - 1
 
     for tag_values in index.tag_map.values():
         for values in tag_values.values():
@@ -101,12 +101,12 @@ def test_get_accounts_by_tag(index_obj: Dict[str, Any]) -> None:
 def test_get_accounts_by_ou(index_obj: Dict[str, Any]) -> None:
     """This tests getting accounts by OUs"""
     index = StarfleetDefaultAccountIndex()
-    accounts = index.get_accounts_by_ou("sOMeOu")  # This tests casing as well
+    accounts = index.get_accounts_by_ou("wOrkLOads")  # This tests casing as well
     assert len(accounts) == len(index_obj["accounts"].keys()) - 1
     assert "000000000020" not in accounts  # We didn't search for Root
 
     # Try this again, but this time pass in the OU ID. It should be the same result:
-    assert index.get_accounts_by_ou("oU-1234-5678910") == accounts  # Also test casing
+    assert index.get_accounts_by_ou("oU-abcd-e604f59w") == accounts  # Also test casing
 
 
 def test_get_accounts_by_regions(index_obj: Dict[str, Any]) -> None:

--- a/tests/test_configuration_files/account_index_generator.yaml
+++ b/tests/test_configuration_files/account_index_generator.yaml
@@ -7,5 +7,5 @@ AccountIndexGeneratorShip:
   EventBridgeTimedFrequency: HOURLY
   OrgAccountAssumeRole: starfleet-worker-basic-test-role
   OrgAccountId: "123456789012"
-  OrgRootId: r-123456
+  OrgRootId: r-abcd
   DescribeRegionsAssumeRole: starfleet-worker-basic-test-role


### PR DESCRIPTION
This change introduces a fix to resolve the unhandled exception and crash when the `AccountIndexGeneratorShip` attempts to generate the account inventory for an organization with a nested OU hierarchy.

The `get_organizational_unit_map` function in `starfleet.worker_ships.plugins.account_index_generator.utils` is a recursive function that returns a map of all organizational unit names keyed to their identifier, including the organization root:

```json
{
  "r-abcd": "ROOT",
  "ou-abcd-e604f59w": "Regulated Workloads",
  "ou-abcd-q8z9vop9": "Prod",
  "ou-abcd-nndadfrq": "Non-Prod",
  "ou-abcd-7puk9u2d": "Sandbox",
  "ou-abcd-u144jfki": "Security",
  "ou-abcd-q97w37sn": "Core Infrastructure"
}
```

The test fixtures and mock data have been updated to support testing of account inventory generation and resolvers with accounts that are contained at the root of the organization, in top-level OUs, and in nested OUs.

Resolves #24 