### PR TITLE
Updated CloudAux dependency to pull from cloudaux-lite

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/src/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-cloudaux @ git+https://github.com/mikegrima/cloudaux@TwoPointZero
+cloudaux-lite==1.0.0
 click==8.1.3
 PyYAML==6.0
 marshmallow==3.19.0


### PR DESCRIPTION
Removed the git pulling reference and using the fresh and new `cloudaux-lite` package on PyPI.