### PR TITLE
Fixed issue with AWS Config API Changes

### DIFF
--- a/src/starfleet/worker_ships/ship_schematics.py
+++ b/src/starfleet/worker_ships/ship_schematics.py
@@ -137,8 +137,6 @@ class StarfleetWorkerShip:
     The instantiated object type hint is `StarFleetWorkerShipInstance`.
     """
 
-    # TODO: Should the invocation sources be defined here or the configuration?? (right now it's in the configuration)
-
     # This is the template class for the worker ship. All worker ship payload templates need to be defined.
     payload_template_class: Type[WorkerShipPayloadBaseTemplate] = WorkerShipPayloadBaseTemplate  # Default to the base
     payload: WorkerShipPayloadBaseTemplateInstance

--- a/tests/starfleet_included_plugins/aws_config/test_logic.py
+++ b/tests/starfleet_included_plugins/aws_config/test_logic.py
@@ -61,6 +61,7 @@ def test_get_current_state(aws_config: BaseClient) -> None:
     )
     confirm_values = {}
     current_state = get_current_state("000000000001", "us-east-2", "AssumeThisRole", "StarfleetAwsConfig")
+    # TODO: Need to update this with latest changes made to config API in June 2023!
     assert current_state["ConfigurationRecorder"] == {
         "name": "test",
         "recordingGroup": {"allSupported": True, "includeGlobalResourceTypes": True, "resourceTypes": []},


### PR DESCRIPTION
- AWS Config is making changes to their API around the recording group
- The changes introduces new fields that cause the worker to think that there are changes that need to be set
- Logic has been introduced to only compare the fields we specifically care about