### PR TITLE
Dependabot update to group boto dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,13 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
+  - package-ecosystem: "pip"
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    groups:
+      # This is the name of your group, it will be used in PR titles and branch names
+      boto-dependencies:
+        # A pattern can be...
+        patterns:
+          - "boto*"


### PR DESCRIPTION
- Groups all the botocore dependencies since they are supposed to be upgraded together.

See: https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/ for details