### PR TITLE
Fixed issue with IAMbic's logger overrider

### DIFF
--- a/src/starfleet/worker_ships/plugins/iam/iambic_imports.py
+++ b/src/starfleet/worker_ships/plugins/iam/iambic_imports.py
@@ -10,8 +10,34 @@ from unittest import mock
 
 from starfleet.utils.logging import LOGGER
 
+
+def _format_message(message: str, **kwargs) -> str:
+    """Takes in the logging message and the kwargs and formats them so the default Python logger will be happy."""
+    return f"{message} - logger_kwargs: {kwargs}"
+
+
+class StarfleetIAMbicLoggerOverrider:
+    """Class that addresses IAMbic's custom logging functionality."""
+
+    def debug(self, text: str, **kwargs) -> None:
+        """Mocks out the IAMbic logger debug log."""
+        LOGGER.debug(_format_message(text, **kwargs))
+
+    def info(self, text: str, **kwargs) -> None:
+        """Mocks out the IAMbic logger info log."""
+
+        LOGGER.info(_format_message(text, **kwargs))
+
+    def error(self, text: str, **kwargs) -> None:
+        """Mocks out the IAMbic logger error log."""
+
+        LOGGER.error(_format_message(text, **kwargs))
+
+
+iambic_logger = StarfleetIAMbicLoggerOverrider()
+
 # Mock out the iambic logger, as it's bossy and overrides Starfleet's:
-mock.patch("iambic.core.logger.log", LOGGER).start()
+mock.patch("iambic.core.logger.log", iambic_logger).start()
 
 # Now continue to import the rest:
 from iambic.core.context import ctx as iambic_ctx  # noqa: E402,F401

--- a/tests/starfleet_included_plugins/iam/test_role_ship.py
+++ b/tests/starfleet_included_plugins/iam/test_role_ship.py
@@ -227,3 +227,19 @@ def test_iambic_exceptions(test_index: AccountIndexInstance, template: Dict[str,
         assert mocked_logger.error.call_args[0][0].startswith("[❌] Iambic encountered the following exceptions:")
         assert "Some Exception" in mocked_logger.error.call_args[0][0]
         assert "Some Other Exception" in mocked_logger.error.call_args[0][0]
+
+
+def test_iambic_logger() -> None:
+    """This tests that the IAMbic logger overrider works as expected. This tests all the entry points to the formatter."""
+    with mock.patch("starfleet.worker_ships.plugins.iam.iambic_imports.LOGGER") as mocked_logger:
+        from iambic.core.logger import log
+
+        some_kwargs = {"some": "value", "some_other": "value"}
+
+        log.debug("some debug message", an="arg", **some_kwargs)
+        log.info("some info message", an="arg", **some_kwargs)
+        log.error("some error message", an="arg", **some_kwargs)
+
+    mocked_logger.debug.assert_called_once_with("some debug message - logger_kwargs: {'an': 'arg', 'some': 'value', 'some_other': 'value'}")
+    mocked_logger.info.assert_called_once_with("some info message - logger_kwargs: {'an': 'arg', 'some': 'value', 'some_other': 'value'}")
+    mocked_logger.error.assert_called_once_with("some error message - logger_kwargs: {'an': 'arg', 'some': 'value', 'some_other': 'value'}")


### PR DESCRIPTION
- Fixed a bug with IAMbic's logger overriding capabilities
- The IAMbic logger is overriden to use the standard Python one which is consistent with the rest of Starfleet
- An exception was being raised when the logger would encounter keyword arguments passed in
- This PR reformats the text sent to the Python logger to clean up the passed in kwargs