### PR TITLE
:lipstick: Fix issue with output of --help getting truncated

### DIFF
--- a/src/starfleet/worker_ships/plugins/account_index_generator/ship.py
+++ b/src/starfleet/worker_ships/plugins/account_index_generator/ship.py
@@ -121,7 +121,7 @@ def account_inventory(ctx: Context) -> None:
     ctx.obj = AccountIndexGeneratorShip()
 
 
-@account_inventory.command(cls=StarfleetSingleInvokeCommand)
+@account_inventory.command(cls=StarfleetSingleInvokeCommand, short_help="This will generate an AWS account inventory from the organizations API")
 @click.pass_context
 def generate(ctx: Context, commit: bool, **kwargs) -> None:  # noqa # pylint: disable=unused-argument
     """This will generate an AWS account inventory from the organizations API"""


### PR DESCRIPTION
Implemented Click's "short_help" in order to avoid truncated output.