### PR TITLE
Corrected Deprecation Warnings

### DIFF
--- a/src/starfleet/worker_ships/plugins/account_index_generator/ship.py
+++ b/src/starfleet/worker_ships/plugins/account_index_generator/ship.py
@@ -9,7 +9,7 @@ This contians the entrypoints for both the CLI and Lambda as well.
 :Author: Mike Grima <michael.grima@gemini.com>
 """
 
-from datetime import datetime
+from datetime import datetime, UTC
 import json
 from typing import Dict, Any, TypeVar
 
@@ -91,7 +91,7 @@ class AccountIndexGeneratorShip(StarfleetWorkerShip):
 
         # Save it to S3:
         if commit:
-            dump_accounts = {"accounts": account_map, "generated": datetime.utcnow().replace(tzinfo=None, microsecond=0).isoformat() + "Z"}
+            dump_accounts = {"accounts": account_map, "generated": datetime.now(UTC).replace(tzinfo=None, microsecond=0).isoformat() + "Z"}
             LOGGER.info(f"[🪣] Saving the report as {self.payload['inventory_object_prefix']} in {self.payload['account_inventory_bucket']}")
             client = boto3.client("s3", region_name=self.payload["inventory_bucket_region"])
             client.put_object(

--- a/test_sam_template.yaml
+++ b/test_sam_template.yaml
@@ -129,7 +129,7 @@ Resources:
     Properties:
       CodeUri: ./src
       Handler: starfleet.starbase.entrypoints.eventbridge_timed_lambda_handler
-      Runtime: python3.10
+      Runtime: python3.12
       Architectures:
         - arm64
       Events:
@@ -226,7 +226,7 @@ Resources:
     Properties:
       CodeUri: ./src
       Handler: starfleet.worker_ships.plugins.account_index_generator.ship.lambda_handler
-      Runtime: python3.10
+      Runtime: python3.12
       Architectures:
         - arm64
       MemorySize: 256
@@ -268,7 +268,7 @@ Resources:
 #    Properties:
 #      CodeUri: ./src
 #      Handler: starfleet.worker_ships.plugins.aws_config.ship.lambda_handler
-#      Runtime: python3.10
+#      Runtime: python3.12
 #      Architectures:
 #        - arm64
 #      MemorySize: 128
@@ -308,7 +308,7 @@ Resources:
 #    Properties:
 #      CodeUri: ./src
 #      Handler: starfleet.worker_ships.plugins.github_sync.ship.lambda_handler
-#      Runtime: python3.10
+#      Runtime: python3.12
 #      Architectures:
 #        - arm64
 #      MemorySize: 128
@@ -349,7 +349,7 @@ Resources:
 #    Properties:
 #      CodeUri: ./starfleet/src
 #      Handler: starfleet.worker_ships.plugins.iam.role_ship.lambda_handler
-#      Runtime: python3.10
+#      Runtime: python3.12
 #      Architectures:
 #        - arm64
 #      MemorySize: 128
@@ -376,7 +376,7 @@ Resources:
     Properties:
       CodeUri: ./src
       Handler: starfleet.starbase.entrypoints.fanout_payload_lambda_handler
-      Runtime: python3.10
+      Runtime: python3.12
       Architectures:
         - arm64
       Events:

--- a/tests/starfleet_included_plugins/account_index_generator/conftest.py
+++ b/tests/starfleet_included_plugins/account_index_generator/conftest.py
@@ -10,7 +10,7 @@ This defines the PyTest fixtures exclusively for the Account Indexer worker
 
 # pylint: disable=redefined-outer-name,unused-argument,duplicate-code
 import json
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Any, Dict, Generator, Optional
 from unittest import mock
 from unittest.mock import MagicMock
@@ -96,7 +96,7 @@ def account_generator(paginator: Optional[str] = None) -> Dict[str, Any]:
                 "Name": f"Account {count + 1}",
                 "Status": "ACTIVE",
                 "JoinedMethod": "INVITED",
-                "JoinedTimestamp": datetime.utcnow(),
+                "JoinedTimestamp": datetime.now(UTC),
             }
         )
 

--- a/tests/starfleet_included_plugins/github_sync/conftest.py
+++ b/tests/starfleet_included_plugins/github_sync/conftest.py
@@ -12,7 +12,7 @@ All the Pytest fixtures unique to the GitHub Sync worker
 import base64
 from io import BytesIO
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 import tempfile
 import random
 import string
@@ -102,7 +102,7 @@ def mock_installation_token(unit_test_secrets: Dict[str, Any]) -> Generator[Magi
         def json(self) -> Dict[str, Any]:
             """Mocked out the JSON function to return a fake token back out."""
             # Make expiration 1 hour from now:
-            time_stamp = (datetime.utcnow().replace(tzinfo=None, microsecond=0) + timedelta(minutes=60)).isoformat() + "Z"
+            time_stamp = (datetime.now(UTC).replace(tzinfo=None, microsecond=0) + timedelta(minutes=60)).isoformat() + "Z"
             return {"expires_at": time_stamp, "token": "lolsometoken"}
 
     mocked_requests = MagicMock()

--- a/tests/starfleet_included_plugins/github_sync/test_auth.py
+++ b/tests/starfleet_included_plugins/github_sync/test_auth.py
@@ -9,7 +9,7 @@ Tests out the authentication code for GitHub.
 """
 
 # pylint: disable=unused-argument,too-many-arguments,too-many-locals
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 from typing import Any, Dict
 from unittest import mock
 from unittest.mock import MagicMock
@@ -47,7 +47,7 @@ def test_make_installation_token(mock_installation_token: MagicMock) -> None:
     auth_manager._make_installation_token("fakeorg", "987654")
 
     assert auth_manager._installation_tokens["fakeorg"]["token"] == "lolsometoken"
-    assert auth_manager._installation_tokens["fakeorg"]["expiration"] > int(datetime.utcnow().timestamp())
+    assert auth_manager._installation_tokens["fakeorg"]["expiration"] > int(datetime.now(UTC).timestamp())
 
     # Test with an invalid status code:
     mock_installation_token.post.return_value.status_code = 401

--- a/tests/worker_ship_utils/test_niceties.py
+++ b/tests/worker_ship_utils/test_niceties.py
@@ -129,7 +129,7 @@ def test_unwrap_json() -> None:
     assert un_wrap_json(test_nested) == should_equal
 
     # And values that are non-JSON:
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.UTC)
     assert un_wrap_json(now) == str(now)
     assert un_wrap_json(19) == 19
     assert un_wrap_json(3.14) == 3.14


### PR DESCRIPTION
- Fixed the `datetime.utcnow()` depcreation warnings
- Still many warnings but those are being caused by botocore and are not related to Starfleet The botocore related ones will be fixed in the future.
- Also updated the test template for Python 3.12