### PR TITLE
Github Actions: Pin versions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,9 +13,9 @@ jobs:
         python-version:
           - "3.12"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4.9.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Tox


### PR DESCRIPTION
- Pins the two GitHub Actions used by this repo to the latest equivalent version